### PR TITLE
update (#2)

### DIFF
--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -34,9 +34,8 @@ class TestJobs(BaseTest):
     @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
     def test_get_job_by_id_invalid(self, mock_requests):
         job_id = 999
-        self.assertRaises(
-            ThreatMatrixClientException, self.client.get_job_by_id, job_id
-        )
+        with self.assertRaises(ThreatMatrixClientException):
+            self.client.get_job_by_id(job_id)
 
     @mock_connections(
         patch("requests.Session.delete", side_effect=mocked_delete_job_by_id)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -34,7 +34,9 @@ class TestJobs(BaseTest):
     @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
     def test_get_job_by_id_invalid(self, mock_requests):
         job_id = 999
-        self.assertRaises(ThreatMatrixClientException, self.client.get_job_by_id, job_id)
+        self.assertRaises(
+            ThreatMatrixClientException, self.client.get_job_by_id, job_id
+        )
 
     @mock_connections(
         patch("requests.Session.delete", side_effect=mocked_delete_job_by_id)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -31,7 +31,9 @@ class TestTags(BaseTest):
     @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
     def test_get_tag_by_id_invalid(self, mock_requests):
         tag_id = 999
-        self.assertRaises(ThreatMatrixClientException, self.client.get_tag_by_id, tag_id)
+        self.assertRaises(
+            ThreatMatrixClientException, self.client.get_tag_by_id, tag_id
+        )
 
     @mock_connections(patch("requests.Session.post", side_effect=mocked_create_tag))
     def test_create_tag_success(self, mock_requests):
@@ -48,7 +50,9 @@ class TestTags(BaseTest):
     def test_create_tag_failure(self, mock_requests):
         label = "test-tag"
         color = "white"
-        self.assertRaises(ThreatMatrixClientException, self.client.create_tag, label, color)
+        self.assertRaises(
+            ThreatMatrixClientException, self.client.create_tag, label, color
+        )
 
     @mock_connections(patch("requests.Session.put", side_effect=mocked_edit_tag))
     def test_edit_tag_valid_id(self, mock_requests):
@@ -82,4 +86,6 @@ class TestTags(BaseTest):
     )
     def test_delete_tag_by_id_failure(self, mock_requests):
         tag_id = 1
-        self.assertRaises(ThreatMatrixClientException, self.client.delete_tag_by_id, tag_id)
+        self.assertRaises(
+            ThreatMatrixClientException, self.client.delete_tag_by_id, tag_id
+        )


### PR DESCRIPTION
### **User description**
# Description

Please include a summary of the change.

## Related issues
Please add related issues.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [ ] The pull request is for the branch develop
- [ ] I have added tests in the [Tests](https://github.com/khulnasoft/pythreatmatrix/tree/master/tests) folder. 
- [ ] The tests gave 0 errors.
- [ ] `Black` gave 0 errors.
- [ ] `Flake` gave 0 errors.
- [ ] I squashed the commits into a single one. (optional, they will be squashed anyway by the maintainer)
  
### please follow these rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review

# Real World Example

Please delete if the PR is for bug fixing.
Otherwise, please provide the resulting raw JSON of a finished analysis (and, if you like, a screenshot of the results). This is to allow the maintainers to understand how the analyzer works.


___

### **PR Type**
Tests


___

### **Description**
- Reformatted `self.assertRaises` calls in `tests/test_jobs.py` for better readability.
- Reformatted `self.assertRaises` calls in `tests/test_tags.py` for better readability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jobs.py</strong><dd><code>Reformat `self.assertRaises` calls in job tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/test_jobs.py

- Reformatted `self.assertRaises` calls for better readability.



</details>
    

  </td>
  <td><a href="https://github.com/khulnasoft/pythreatmatrix/pull/3/files#diff-ed25e8d31073dc538256a23c9e69a1219c8f0540355913ee1ac124932a8e67f0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_tags.py</strong><dd><code>Reformat `self.assertRaises` calls in tag tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/test_tags.py

- Reformatted `self.assertRaises` calls for better readability.



</details>
    

  </td>
  <td><a href="https://github.com/khulnasoft/pythreatmatrix/pull/3/files#diff-c2a8158c2ea75e325dc5d418fe408374d215b771f40be4a907dca380ad4a6701">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

